### PR TITLE
Finish 1.2, trying out a formatting change

### DIFF
--- a/publication/publication-rs.ptx
+++ b/publication/publication-rs.ptx
@@ -72,7 +72,7 @@
     <!-- The next elements say how the levels deep to break up the    -->
     <!-- numbering of the respective elements. Can't be more than the -->
     <!-- @level on divisions above.                                   -->
-      <!--<blocks level="2" />-->
+      <blocks level="3" />
       <!--<projects level="2" />-->
       <!--<equations level="2" />-->
       <!--<footnotes level="2" />-->

--- a/publication/publication.ptx
+++ b/publication/publication.ptx
@@ -67,11 +67,12 @@
     <!-- For use with a book organized by part, you can set the -->
     <!--  @part-structure to "decorative" or "structural" -->
       <!--<divisions part-structure="decorative" chapter-start="0" level="2"/>-->
+      <division level="3" />
 
     <!-- The next elements say how the levels deep to break up the    -->
     <!-- numbering of the respective elements. Can't be more than the -->
     <!-- @level on divisions above.                                   -->
-      <!--<blocks level="2" />-->
+      <blocks level="3" />
       <!--<projects level="2" />-->
       <!--<equations level="2" />-->
       <!--<footnotes level="2" />-->

--- a/source/bookinfo.xml
+++ b/source/bookinfo.xml
@@ -57,6 +57,6 @@
   <!-- PreTeXt doesn't like renaming to whitespace, so using U+3164 (Hangul Filler) -->
   <!-- here inside the rename element. -->
   <rename element="worksheet" xml:lang="en-US"> </rename>
-  <!-- <rename element="inlineexercise" xml:lang="en-US">Question</rename> -->
+  <rename element="inlineexercise" xml:lang="en-US">Exercise</rename>
 </docinfo>
 

--- a/source/bookinfo.xml
+++ b/source/bookinfo.xml
@@ -51,12 +51,12 @@
   </blurb>
   <rename element="exploration" xml:lang="en-US">Preview Activity</rename>
 
-  <rename element="objectives" xml:lang="en-US">Section Objectives</rename>
+  <!-- <rename element="objectives" xml:lang="en-US">Section Objectives</rename> -->
   <rename element="outcomes" xml:lang="en-US">Foundations</rename>
-  <rename element="inlineexercise" xml:lang="en-US">Exercise</rename>
+  <rename element="inlineexercise" xml:lang="en-US">Foundational Exercise</rename>
   <!-- PreTeXt doesn't like renaming to whitespace, so using U+3164 (Hangul Filler) -->
   <!-- here inside the rename element. -->
   <rename element="worksheet" xml:lang="en-US"> </rename>
-  <rename element="inlineexercise" xml:lang="en-US">Exercise</rename>
+  <!-- <rename element="inlineexercise" xml:lang="en-US">Exercise</rename> -->
 </docinfo>
 

--- a/source/sec-1-1-vel.xml
+++ b/source/sec-1-1-vel.xml
@@ -38,24 +38,31 @@
   
 
   <!-- do we put them into separate files for easier editing later? -->
-  
-
-  <subsection><title>Additional Section Exercises</title>
-    <!-- <exercises xmlns:xi="http://www.w3.org/2001/XInclude" xml:id="ez-1-1"><title>Additional Exercises</title> -->
-  <!-- <exercise label="limits-from-graph-1">
-    <webwork><xi:include parse="text" href="../webworkfiles/sec_1-2_prob1.pg"/></webwork>
-  </exercise>
-  <exercise label="limits-from-graph-2">
-    <webwork source="Library/Valdosta/APEX_Calculus/1.4/APEX_1.4_12.pg"/>
-  </exercise> -->
-  
-  <!-- </exercises> -->
-    
-  </subsection>
-
   <subsection><title>Foundational Exercises</title>
     
     
     
   </subsection>
+
+  <exercises><title>Additional Practice Exercises</title>
+    <!-- <exercises xmlns:xi="http://www.w3.org/2001/XInclude" xml:id="ez-1-1"><title>Additional Exercises</title> -->
+  <!-- <exercise label="limits-from-graph-1">
+    <webwork><xi:include parse="text" href="../webworkfiles/sec_1-2_prob1.pg"/></webwork>
+  </exercise>-->
+  <exercise label="avgchange-from-table-1"><title>Average rate of change from a table</title>
+    <webwork source="Contrib/CCCS/CollegeAlgebra/3.3/RRCC_CCCS_Openstax_AlgTrig_AT-1-001-AS_3_3_26.pg"/>
+  </exercise>
+  <exercise label="avgspeed-from-twovalues-1"><title>Average speed from two values</title>
+    <webwork source="Contrib/CCCS/CollegeAlgebra/3.3/RRCC_CCCS_Openstax_AlgTrig_AT-1-001-AS_3_3_44.pg"/>
+  </exercise>
+  <exercise label="avgchange-from-twovalues-1"><title>Average rate of change from two values</title>
+    <webwork source="Contrib/CCCS/CollegeAlgebra/3.3/RRCC_CCCS_Openstax_AlgTrig_AT-1-001-AS_3_3_45.pg"/>
+  </exercise>
+  
+  
+  
+  </exercises>
+    
+
+  
 </section>

--- a/source/sec-1-2-lim.xml
+++ b/source/sec-1-2-lim.xml
@@ -38,7 +38,79 @@
   <!-- do we put them into separate files for easier editing later? -->
   
 
-  <subsection><title>Additional Section Exercises</title>
+  <subsection><title>Foundational Exercises</title>
+    <p>
+      This section is about limits, the behavior of a function's output value as the input value is getting closer
+      and closer (but not equal to) a specified number.  A function can be described by a graph, a table of values,
+      or by an algebraic formula, so we work on interpreting limits of functions described in graphical, numerical, and algebraic ways.
+    </p>
+    <p>
+      It would be helpful to practice how we can interpret information about a function from a graph, or from a 
+      piecewise description of a function.  Calculating an algebraic limit can also require us to use algebraic simplification
+      techniques such as factoring, combining rational functions using a common denominator, and rationalizing a radical function
+      using the conjugate.  
+    </p>
+    <exercise label="functions-piecewise-1"><title>Values of a piecewise function</title>
+      <webwork source="Contrib/CCCS/CollegeAlgebra/3.2/RRCC_CCCS_Openstax_AlgTrig_AT-1-001-AS_3_2_49.pg"/>
+    </exercise>
+    <exercise label="functions-piecewise-2"><title>Values of a piecewise function</title>
+      <webwork source="Contrib/CCCS/CollegeAlgebra/3.2/RRCC_CCCS_Openstax_AlgTrig_AT-1-001-AS_3_2_51.pg"/>
+    </exercise>
+    <exercise label="functions-find-x-or-y-values-1"><title>Output and input values from a graph</title>
+      <webwork source="Contrib/RRCC/College_Algebra/MAT121/3.1/RRCC_CCCS_Openstax_AlgTrig_AT-1-001-AS_3_1_53.pg"/>
+    </exercise>
+    <exercise label="functions-find-x-or-y-values-2"><title>Values from a graph</title>
+      <webwork source="Library/CollegeOfIdaho/setAlgebra_02_01_IntroFunctions/21IntAlg_14_function.pg"/>
+    </exercise>
+    <exercise label="polynomials-factor-1"><title>Factoring</title>
+      <webwork source="Library/CollegeOfIdaho/setAlgebra_05_03_FactoringByGrouping/53IntAlg_09_FactorGrouping.pg"/>
+    </exercise>
+    <exercise label="polynomials-factor-2"><title>Factoring</title>
+      <webwork source="Library/FortLewis/Algebra/2-2-Distributive-law/MCH1-2-2-12-Distributive-law.pg"/>
+    </exercise>
+    <exercise label="polynomials-factor-3"><title>Factoring</title>
+      <webwork source="Library/PCC/BasicAlgebra/Factoring/factoring115.pg"/>
+    </exercise>
+    <exercise label="polynomials-factor-4"><title>Factoring</title>
+      <webwork source="Contrib/CCCS/QuantitativeLiteracy/IA_6.1/OpenStax_IA_6.1_53.pg"/>
+    </exercise>
+    <exercise label="polynomials-factor-5"><title>Factoring</title>
+      <webwork source="Library/Mizzou/College_Algebra/Factoring_ax2_bx_c/Factoringarbitrary.pg"/>
+    </exercise>
+    <exercise label="polynomials-factor-cancel-1"><title>Factoring numerator and denominator</title>
+      <webwork source="Library/CollegeOfIdaho/setAlgebra_06_01_MultDivRationalExpressions/61IntAlg_08_MultDivRatExp.pg"/>
+    </exercise>
+    <exercise label="polynomials-factor-cancel-2"><title>Factoring numerator and denominator</title>
+      <webwork source="Library/CollegeOfIdaho/setAlgebra_06_01_MultDivRationalExpressions/61IntAlg_09_MultDivRatExp.pg"/>
+    </exercise>
+    <exercise label="adding-rational-functions-1"><title>Adding rational functions</title>
+      <webwork source="Library/FortLewis/Basic-skills-pretest/Skill-Assessment-24.pg"/>
+    </exercise>
+    <exercise label="adding-rational-functions-2"><title>Adding rational functions</title>
+      <webwork source="Library/UMN/algebraKaufmannSchwitters/ks_4_4_28.pg"/>
+    </exercise>
+    <exercise label="adding-rational-functions-3"><title>Adding rational functions</title>
+      <webwork source="Library/UMN/algebraKaufmannSchwitters/ks_5_1_76.pg"/>
+    </exercise>
+    <exercise label="adding-rational-functions-4"><title>Adding rational functions</title>
+      <webwork source="Contrib/CCCS/AlgebraicLiteracy/IA_7.2/OpenStax_IA_7.2_121.pg"/>
+    </exercise>
+    <exercise label="rationalizing-conjugates-1"><title>Radicals and conjugates</title>
+      <webwork source="Contrib/CUNY/CityTech/CollegeAlgebra_Trig/MultiplyRadicals/algebraic-conjugates.pg"/>
+    </exercise>
+    <exercise label="rationalizing-radical-functions-2"><title>Rationalizing radicals</title>
+      <webwork source="Library/Mizzou/Algebra/radicals_rationalizing/denominator_01.pg"/>
+    </exercise> 
+    <exercise label="rationalizing-radical-functions-3"><title>Rationalizing radicals</title>
+      <webwork source="Contrib/CUNY/CityTech/CollegeAlgebra_Trig/RationalizeDenominators/conjugate4-algebra.pg"/>
+    </exercise>
+    <exercise label="rationalizing-radical-functions-4"><title>Rationalizing radicals</title>
+      <webwork source="Library/Mizzou/College_Algebra/Rational_and_Radical_Exponents_Rationalizing/Rationalize2.pg"/>
+    </exercise>
+  </subsection>
+
+
+  <exercises><title>Additional Practice Exercises</title>
     <!-- <exercises xmlns:xi="http://www.w3.org/2001/XInclude" xml:id="ez-1-1"><title>Additional Exercises</title> -->
   <exercise label="limits-from-graph-1"><title>Limits from a graph</title>
     <webwork source="Library/UMN/calculusStewartCCC/s_2_2_5.pg"/>
@@ -101,62 +173,6 @@
   
   <!-- </exercises> -->
     
-  </subsection>
+</exercises>
 
-  <subsection><title>Foundational Exercises</title>
-    <exercise label="functions-piecewise-1"><title>Values of a piecewise function</title>
-      <webwork source="Contrib/CCCS/CollegeAlgebra/3.2/RRCC_CCCS_Openstax_AlgTrig_AT-1-001-AS_3_2_49.pg"/>
-    </exercise>
-    <exercise label="functions-piecewise-2"><title>Values of a piecewise function</title>
-      <webwork source="Contrib/CCCS/CollegeAlgebra/3.2/RRCC_CCCS_Openstax_AlgTrig_AT-1-001-AS_3_2_51.pg"/>
-    </exercise>
-    <exercise label="functions-find-x-or-y-values-1"><title>Output and input values from a graph</title>
-      <webwork source="Contrib/RRCC/College_Algebra/MAT121/3.1/RRCC_CCCS_Openstax_AlgTrig_AT-1-001-AS_3_1_53.pg"/>
-    </exercise>
-    <exercise label="polynomials-factor-1"><title>Factoring</title>
-      <webwork source="Library/CollegeOfIdaho/setAlgebra_05_03_FactoringByGrouping/53IntAlg_09_FactorGrouping.pg"/>
-    </exercise>
-    <exercise label="polynomials-factor-2"><title>Factoring</title>
-      <webwork source="Library/FortLewis/Algebra/2-2-Distributive-law/MCH1-2-2-12-Distributive-law.pg"/>
-    </exercise>
-    <exercise label="polynomials-factor-3"><title>Factoring</title>
-      <webwork source="Library/PCC/BasicAlgebra/Factoring/factoring115.pg"/>
-    </exercise>
-    <exercise label="polynomials-factor-4"><title>Factoring</title>
-      <webwork source="Contrib/CCCS/QuantitativeLiteracy/IA_6.1/OpenStax_IA_6.1_53.pg"/>
-    </exercise>
-    <exercise label="polynomials-factor-5"><title>Factoring</title>
-      <webwork source="Library/Mizzou/College_Algebra/Factoring_ax2_bx_c/Factoringarbitrary.pg"/>
-    </exercise>
-    <exercise label="polynomials-factor-cancel-1"><title>Factoring numerator and denominator</title>
-      <webwork source="Library/CollegeOfIdaho/setAlgebra_06_01_MultDivRationalExpressions/61IntAlg_08_MultDivRatExp.pg"/>
-    </exercise>
-    <exercise label="polynomials-factor-cancel-2"><title>Factoring numerator and denominator</title>
-      <webwork source="Library/CollegeOfIdaho/setAlgebra_06_01_MultDivRationalExpressions/61IntAlg_09_MultDivRatExp.pg"/>
-    </exercise>
-    <exercise label="adding-rational-functions-1"><title>Adding rational functions</title>
-      <webwork source="Library/FortLewis/Basic-skills-pretest/Skill-Assessment-24.pg"/>
-    </exercise>
-    <exercise label="adding-rational-functions-2"><title>Adding rational functions</title>
-      <webwork source="Library/UMN/algebraKaufmannSchwitters/ks_4_4_28.pg"/>
-    </exercise>
-    <exercise label="adding-rational-functions-3"><title>Adding rational functions</title>
-      <webwork source="Library/UMN/algebraKaufmannSchwitters/ks_5_1_76.pg"/>
-    </exercise>
-    <exercise label="adding-rational-functions-4"><title>Adding rational functions</title>
-      <webwork source="Contrib/CCCS/AlgebraicLiteracy/IA_7.2/OpenStax_IA_7.2_121.pg"/>
-    </exercise>
-    <exercise label="rationalizing-conjugates-1"><title>Radicals and conjugates</title>
-      <webwork source="Contrib/CUNY/CityTech/CollegeAlgebra_Trig/MultiplyRadicals/algebraic-conjugates.pg"/>
-    </exercise>
-    <exercise label="rationalizing-radical-functions-2"><title>Rationalizing radicals</title>
-      <webwork source="Library/Mizzou/Algebra/radicals_rationalizing/denominator_01.pg"/>
-    </exercise> 
-    <exercise label="rationalizing-radical-functions-3"><title>Rationalizing radicals</title>
-      <webwork source="Contrib/CUNY/CityTech/CollegeAlgebra_Trig/RationalizeDenominators/conjugate4-algebra.pg"/>
-    </exercise>
-    <exercise label="rationalizing-radical-functions-4"><title>Rationalizing radicals</title>
-      <webwork source="Library/Mizzou/College_Algebra/Rational_and_Radical_Exponents_Rationalizing/Rationalize2.pg"/>
-    </exercise>
-  </subsection>
 </section>

--- a/source/sec-1-2-lim.xml
+++ b/source/sec-1-2-lim.xml
@@ -40,52 +40,63 @@
 
   <subsection><title>Additional Section Exercises</title>
     <!-- <exercises xmlns:xi="http://www.w3.org/2001/XInclude" xml:id="ez-1-1"><title>Additional Exercises</title> -->
-  <exercise label="limits-from-graph-1">
-    <webwork><xi:include parse="text" href="../webworkfiles/sec_1-2_prob1.pg"/></webwork>
-  </exercise>
-  <exercise label="limits-from-graph-2">
+  <exercise label="limits-from-graph-1"><title>Limits from a graph</title>
+    <webwork source="Library/UMN/calculusStewartCCC/s_2_2_5.pg"/>
+    <!-- <webwork><xi:include parse="text" href="../webworkfiles/sec_1-2_prob1.pg"/></webwork> -->
+  </exercise> 
+  <!-- weird cached image stuff happening with problem above.  -->
+  <exercise label="limits-from-graph-2"><title>Limits from a graph</title>
     <webwork source="Library/Valdosta/APEX_Calculus/1.4/APEX_1.4_12.pg"/>
   </exercise>
-  <exercise label="limits-from-graph-3">
+  <exercise label="limits-from-graph-3"><title>Limits from a graph</title>
     <webwork source="Library/WHFreeman/Rogawski_Calculus_Early_Transcendentals_Second_Edition/2_Limits/2.2_Limits-_A_Numerical_and_Graphical_Approach/2.2.5.pg"/>
   </exercise>
-  <exercise label="limits-from-graph-4">
+  <exercise label="limits-from-graph-4"><title>Limits from a graph</title>
     <webwork source="Library/UMN/calculusStewartCCC/s_2_2_6.pg"/>
   </exercise>
-  <exercise label="limits-from-piecewise-1">
+  <exercise label="limits-from-piecewise-1"><title>Limits with a piecewise function</title>
     <webwork source="Library/Valdosta/APEX_Calculus/1.1/APEX_1.1_12.pg"/>
   </exercise>
-  <exercise label="limits-from-table-1">
+  <exercise label="limits-from-table-1"><title>Limits with a table</title>
     <webwork source="Contrib/CCCS/CalculusOne/02.2/CCD_CCCS_Openstax_Calc1_C1-2016-002_02_2_39.pg"/>
   </exercise>
-  <exercise label="limits-from-table-2">
+  <exercise label="limits-from-table-2"><title>Limits with a table</title>
     <webwork source="Contrib/CCCS/CalculusOne/02.2/CCD_CCCS_Openstax_Calc1_C1-2016-002_02_2_38.pg"/>
   </exercise>
 
-  <exercise label="limits-algebraic-1">
+  <exercise label="limits-algebraic-1"><title>Algebraic limit</title>
     <webwork source="Library/ASU-topics/setLimitConcepts/3-2-25.pg"/>
   </exercise>
-  <exercise label="limits-factor-1">
+  <exercise label="limits-factor-1"><title>Algebraic limit: factoring</title>
     <webwork source="Contrib/Hope/Calc1/APEX_01_03_Limits_analytical/Limit_02a.pg"/>
   </exercise>
-  <exercise label="limits-factor-2">
+  <exercise label="limits-factor-2"><title>Algebraic limit: factoring</title>
     <webwork source="Contrib/Hope/Calc1/APEX_01_03_Limits_analytical/Limit_03a.pg"/>
   </exercise>
-  <exercise label="limits-factor-3">
+  <exercise label="limits-factor-3"><title>Algebraic limit: factoring</title>
     <webwork source="Contrib/Hope/Calc1/APEX_01_03_Limits_analytical/Limit_03b.pg"/>
   </exercise>
-  <exercise label="limits-fractions-1">
+  <exercise label="limits-fractions-1"><title>Algebraic limit: common denominator</title>
     <webwork source="Contrib/Hope/Calc1/APEX_01_03_Limits_analytical/Limit_06.pg"/>
   </exercise>
-  <exercise label="limits-fractions-2">
+  <exercise label="limits-fractions-2"><title>Algebraic limit: common denominator</title>
     <webwork source="Contrib/Hope/Calc1/APEX_01_03_Limits_analytical/Limit_05.pg"/>
   </exercise>
-  <exercise label="limits-rationalize-1">
+  <exercise label="limits-rationalize-1"><title>Algebraic limit: rationalizing and conjugate</title>
     <webwork source="Library/UCSB/Stewart5_2_3/Stewart5_2_3_23.pg"/>
   </exercise>
-  <exercise label="limits-rationalize-2">
+  <exercise label="limits-rationalize-2"><title>Algebraic limit: rationalizing and conjugate</title>
     <webwork source="Library/WHFreeman/Rogawski_Calculus_Early_Transcendentals_Second_Edition/2_Limits/2.5_Evaluating_Limits_Algebraically/2.5.21.pg"/>
   </exercise>
+  <exercise label="average-instant-velocity-1"><title>Average and instantaneous velocity</title>
+    <webwork source="Library/WHFreeman/Rogawski_Calculus_Early_Transcendentals_Second_Edition/2_Limits/2.1_Limits_Rates_of_Change_and_Tangent_Lines/2.1.1.pg"/>
+  </exercise>
+  <exercise label="average-instant-velocity-2"><title>Average and instantaneous velocity</title>
+    <webwork source="Library/Rochester/setLimitsRates6Rates/s1_6_14.pg"/>
+  </exercise>
+  
+  
+  
   
   
   <!-- </exercises> -->
@@ -93,8 +104,59 @@
   </subsection>
 
   <subsection><title>Foundational Exercises</title>
-    
-    
-    
+    <exercise label="functions-piecewise-1"><title>Values of a piecewise function</title>
+      <webwork source="Contrib/CCCS/CollegeAlgebra/3.2/RRCC_CCCS_Openstax_AlgTrig_AT-1-001-AS_3_2_49.pg"/>
+    </exercise>
+    <exercise label="functions-piecewise-2"><title>Values of a piecewise function</title>
+      <webwork source="Contrib/CCCS/CollegeAlgebra/3.2/RRCC_CCCS_Openstax_AlgTrig_AT-1-001-AS_3_2_51.pg"/>
+    </exercise>
+    <exercise label="functions-find-x-or-y-values-1"><title>Output and input values from a graph</title>
+      <webwork source="Contrib/RRCC/College_Algebra/MAT121/3.1/RRCC_CCCS_Openstax_AlgTrig_AT-1-001-AS_3_1_53.pg"/>
+    </exercise>
+    <exercise label="polynomials-factor-1"><title>Factoring</title>
+      <webwork source="Library/CollegeOfIdaho/setAlgebra_05_03_FactoringByGrouping/53IntAlg_09_FactorGrouping.pg"/>
+    </exercise>
+    <exercise label="polynomials-factor-2"><title>Factoring</title>
+      <webwork source="Library/FortLewis/Algebra/2-2-Distributive-law/MCH1-2-2-12-Distributive-law.pg"/>
+    </exercise>
+    <exercise label="polynomials-factor-3"><title>Factoring</title>
+      <webwork source="Library/PCC/BasicAlgebra/Factoring/factoring115.pg"/>
+    </exercise>
+    <exercise label="polynomials-factor-4"><title>Factoring</title>
+      <webwork source="Contrib/CCCS/QuantitativeLiteracy/IA_6.1/OpenStax_IA_6.1_53.pg"/>
+    </exercise>
+    <exercise label="polynomials-factor-5"><title>Factoring</title>
+      <webwork source="Library/Mizzou/College_Algebra/Factoring_ax2_bx_c/Factoringarbitrary.pg"/>
+    </exercise>
+    <exercise label="polynomials-factor-cancel-1"><title>Factoring numerator and denominator</title>
+      <webwork source="Library/CollegeOfIdaho/setAlgebra_06_01_MultDivRationalExpressions/61IntAlg_08_MultDivRatExp.pg"/>
+    </exercise>
+    <exercise label="polynomials-factor-cancel-2"><title>Factoring numerator and denominator</title>
+      <webwork source="Library/CollegeOfIdaho/setAlgebra_06_01_MultDivRationalExpressions/61IntAlg_09_MultDivRatExp.pg"/>
+    </exercise>
+    <exercise label="adding-rational-functions-1"><title>Adding rational functions</title>
+      <webwork source="Library/FortLewis/Basic-skills-pretest/Skill-Assessment-24.pg"/>
+    </exercise>
+    <exercise label="adding-rational-functions-2"><title>Adding rational functions</title>
+      <webwork source="Library/UMN/algebraKaufmannSchwitters/ks_4_4_28.pg"/>
+    </exercise>
+    <exercise label="adding-rational-functions-3"><title>Adding rational functions</title>
+      <webwork source="Library/UMN/algebraKaufmannSchwitters/ks_5_1_76.pg"/>
+    </exercise>
+    <exercise label="adding-rational-functions-4"><title>Adding rational functions</title>
+      <webwork source="Contrib/CCCS/AlgebraicLiteracy/IA_7.2/OpenStax_IA_7.2_121.pg"/>
+    </exercise>
+    <exercise label="rationalizing-conjugates-1"><title>Radicals and conjugates</title>
+      <webwork source="Contrib/CUNY/CityTech/CollegeAlgebra_Trig/MultiplyRadicals/algebraic-conjugates.pg"/>
+    </exercise>
+    <exercise label="rationalizing-radical-functions-2"><title>Rationalizing radicals</title>
+      <webwork source="Library/Mizzou/Algebra/radicals_rationalizing/denominator_01.pg"/>
+    </exercise> 
+    <exercise label="rationalizing-radical-functions-3"><title>Rationalizing radicals</title>
+      <webwork source="Contrib/CUNY/CityTech/CollegeAlgebra_Trig/RationalizeDenominators/conjugate4-algebra.pg"/>
+    </exercise>
+    <exercise label="rationalizing-radical-functions-4"><title>Rationalizing radicals</title>
+      <webwork source="Library/Mizzou/College_Algebra/Rational_and_Radical_Exponents_Rationalizing/Rationalize2.pg"/>
+    </exercise>
   </subsection>
 </section>


### PR DESCRIPTION
I like what I understood you to be describing in our meeting... the foundational exercises are the content and are in a subsection, followed by an exercises division containing the additional section practice problems.  I reorganized 1.2 in this way, added some brief description like I saw you did in 2.1, and then I renamed inline exercises as Foundational Exercise, which we'll either need to change back or if you like how I have 1.2, then change the other sections to match this format.  

Besides just feeling more "pretext-y", I think this also makes the different kinds of exercises easier to tell apart on the page, and for an instructor using the builder in Runestone.  